### PR TITLE
service category model setup + seed and link with other models

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -10,4 +10,6 @@ class Service < ApplicationRecord
   validates :time_to_answer, numericality: { only_integer: true }
   validates :disponibility, presence: true
   validates :user, presence: true
+  belongs_to :service_category
+  validates :service_category, presence: true
 end

--- a/app/models/service_category.rb
+++ b/app/models/service_category.rb
@@ -1,0 +1,4 @@
+class ServiceCategory < ApplicationRecord
+	has_many :services, dependent: :destroy
+	validates :name, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,4 +10,6 @@ class User < ApplicationRecord
          has_one_attached :photo
          has_many :services, dependent: :destroy
          has_many :reviews, dependent: :destroy
+         has_many :service_categories, through: :services
+         has_many :bookings, dependent: :destroy
 end

--- a/db/migrate/20200508144539_create_service_categories.rb
+++ b/db/migrate/20200508144539_create_service_categories.rb
@@ -1,0 +1,9 @@
+class CreateServiceCategories < ActiveRecord::Migration[6.0]
+  def change
+    create_table :service_categories do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200508144935_add_service_category_ref_to_services.rb
+++ b/db/migrate/20200508144935_add_service_category_ref_to_services.rb
@@ -1,0 +1,5 @@
+class AddServiceCategoryRefToServices < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :services, :service_category, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_07_235637) do
+ActiveRecord::Schema.define(version: 2020_05_08_144935) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -58,6 +58,12 @@ ActiveRecord::Schema.define(version: 2020_05_07_235637) do
     t.index ["user_id"], name: "index_reviews_on_user_id"
   end
 
+  create_table "service_categories", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
   create_table "services", force: :cascade do |t|
     t.string "name"
     t.text "description"
@@ -67,6 +73,8 @@ ActiveRecord::Schema.define(version: 2020_05_07_235637) do
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "service_category_id"
+    t.index ["service_category_id"], name: "index_services_on_service_category_id"
     t.index ["user_id"], name: "index_services_on_user_id"
   end
 
@@ -96,5 +104,6 @@ ActiveRecord::Schema.define(version: 2020_05_07_235637) do
   add_foreign_key "bookings", "users"
   add_foreign_key "reviews", "bookings"
   add_foreign_key "reviews", "users"
+  add_foreign_key "services", "service_categories"
   add_foreign_key "services", "users"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,9 +9,12 @@
 require 'faker'
 require 'open-uri'
 
-puts 'Cleaning all users and services'
+puts 'Cleaning all users, service categories and services'
+Booking.destroy_all
 User.destroy_all
-puts 'User and services cleaned'
+ServiceCategory.destroy_all
+puts 'User, service categories and services cleaned'
+
 
 puts "creating users"
 10.times do 
@@ -32,9 +35,22 @@ puts "creating users"
 
 end
 
+puts 'Creating Service Categories'
+
+# Definir depois as categorias de serviços que queremos
+categories = ["Assistência Técnica", "Aulas", "Autos", "Consultoria",
+    "Design e Tecnologia", "Eventos", "Moda e Beleza", "Reformas", "Saúde", "Serviços Domésticos"]
+categories.each do |category|
+    ServiceCategory.create(name: category)
+end
+
+puts 'Service categories created'
+
 puts 'Creating services for each user'
 
 @users = User.all
+@categories = ServiceCategory.all
+
 @users.each do |user|
     rand(2..10).times do
         # Slow but working
@@ -47,6 +63,7 @@ puts 'Creating services for each user'
         service.time_to_answer = rand(1..7)
         service.disponibility = Faker::Date.between(from: Date.today, to: 8.days.from_now)
         service.user = user
+        service.service_category = @categories.sample
         # puts 'Adding photo to service'
         # service.photo.attach(io: file, filename: 'service.png', content_type: 'image/png')
         service.save ? (puts 'service saved') : (puts "invalid service: #{service.errors.full_messages}")
@@ -56,22 +73,22 @@ end
 
 puts "Creating bookings"
 
-#@users = User.all
+@services = Service.all
+
 @users.each do |user|
     rand(1..5).times do
         booking = Booking.new
-        booking.service_id = rand(1..Service.count)
+        booking.service = @services.sample
         booking.user = user
         booking.date = Faker::Date.between(from: Date.today, to: 8.days.from_now)
 
         # Não sei quais vão ser o status ainda, depois a gente arruma os possiveis
         booking.status = ["Confirmado", "Aguardando confirmação", "Declinado"].sample
         booking.save ? (puts 'booking saved') : (puts "invalid booking: #{booking.errors.full_messages}")
-
     end
 end
 
 puts "#{User.count } Users have been created"
 puts "#{Service.count } Services have been created"
 puts "#{Booking.count } Bookings have been created"
-
+puts "#{ServiceCategory.count} Service Categories have been created"

--- a/test/models/service_category_test.rb
+++ b/test/models/service_category_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class ServiceCategoryTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Criei o modelo para Service Category.

Apesar dele ser segundario, acho que sera mais facil para organizar a visualizacao no site
no home por exemplo, ter os cards de cada category para depois mostrar os servicos desse tipo..

pois o modelo Service, cria instancias cada vez => isso é teremos varias "limpezas de apt" ...

com categoria, todas as instancias de Service ja estarao organizadas

@aurelien-jacomy @victoralbanezi 