### PR TITLE
Alerts

### DIFF
--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -20,13 +20,17 @@ class Booking < ApplicationRecord
   	(["Realizado", "Cancelado"].include?(status)) && (self.review.nil?)
   end
   
-  def self.pending_reviews?(user)
+  def self.pending_reviews(user)
      my_bookings = Booking.where('user_id = ? AND status = ? AND date > ?', user.id, "Realizado", Date.today - 7)
      my_bookings_without_review = []
      my_bookings.each do |booking|
       my_bookings_without_review << booking if booking.review.nil? 
      end
-     my_bookings_without_review.count.zero? ? false : my_bookings_without_review.count
+     my_bookings_without_review.count
+  end
+
+  def self.pending_confirmations(user)
+    my_confirmations = Booking.joins(:service).where('services.user_id = ? AND status = ?', user.id, "Aguardando confirmação").count
   end
 
 end

--- a/app/views/shared/_flashes.html.erb
+++ b/app/views/shared/_flashes.html.erb
@@ -29,8 +29,9 @@
     <%= link_to bookings_path do  %>
       <div class="alert alert-warning w-100 my-4" role="alert">
         <% booking_count = Booking.pending_confirmations(current_user) %>
-        You have <%= booking_count %> booking<%= booking_count > 1 ? "s" : "" %> pending confirmation. Click to leave confirm or decline.
+        You have <%= booking_count %> booking<%= booking_count > 1 ? "s" : "" %> pending confirmation. Click here to confirm or decline.
       </div>
     <% end %>
   <% end %>
+
 <% end %>

--- a/app/views/shared/_flashes.html.erb
+++ b/app/views/shared/_flashes.html.erb
@@ -16,11 +16,20 @@
 <% end %>
 
 <% if user_signed_in? %>
-  <% if Booking.pending_reviews?(current_user) %>
+  <% if Booking.pending_reviews(current_user) > 0 %>
     <%= link_to bookings_path do  %>
       <div class="alert alert-light w-100 my-4" role="alert">
-        <% booking_count = Booking.pending_reviews?(current_user) %>
+        <% booking_count = Booking.pending_reviews(current_user) %>
         You have <%= booking_count %> booking<%= booking_count > 1 ? "s" : "" %> pending a review. Click to leave a review.
+      </div>
+    <% end %>
+  <% end %>
+
+  <% if Booking.pending_confirmations(current_user) > 0 %>
+    <%= link_to bookings_path do  %>
+      <div class="alert alert-warning w-100 my-4" role="alert">
+        <% booking_count = Booking.pending_confirmations(current_user) %>
+        You have <%= booking_count %> booking<%= booking_count > 1 ? "s" : "" %> pending confirmation. Click to leave confirm or decline.
       </div>
     <% end %>
   <% end %>


### PR DESCRIPTION
Quando um dos serviços é solicitado, uma alerta aparece para você confirmar ou recusar o serviço. 
Alterei também a lógica to metodo Booking.pending_reviews? em vez de ser false, ele retorna a quantidade de booking faltando review. Idem para booking faltando confirmação. 

Não consegui implementar uma alerta que diz que um status foi modificado, porque não consigo tirar a alerta uma vez que o usuário a viu. Ela continua aparecendo em todas as páginas. Vou abrir um ticket terça


<img width="916" alt="image" src="https://user-images.githubusercontent.com/59183046/81621802-bdc70a80-93c5-11ea-8462-b015520d64b4.png">
