### PR TITLE
Added date validation and set calendar automatically to first availab…

### DIFF
--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -2,8 +2,8 @@ class Booking < ApplicationRecord
   belongs_to :service
   belongs_to :user
   has_one :review, dependent: :destroy
-
-
+  validate :date_need_to_be_later_than_time_to_answer
+  
   def pending_confirmation?
     self.status == "Aguardando confirmação"
   end
@@ -27,6 +27,14 @@ class Booking < ApplicationRecord
       my_bookings_without_review << booking if booking.review.nil? 
      end
      my_bookings_without_review.count.zero? ? false : my_bookings_without_review.count
+  end
+
+  private 
+
+  def date_need_to_be_later_than_time_to_answer
+    if date < Date.today + self.service.time_to_answer
+      errors.add(:date, "O usuário solicitou ser avisado com #{self.service.time_to_answer} dia#{"s" if self.service.time_to_answer > 1} de antecedência")
+    end
   end
 
 end

--- a/app/views/bookings/new.html.erb
+++ b/app/views/bookings/new.html.erb
@@ -1,6 +1,6 @@
-<%= simple_form_for  [@service, @booking] do |f| %>
-  <%= f.input :date %>
-  <%= f.submit "Book", class: "btn btn-primary" %>
+<%= simple_form_for [@service, @booking] do |f| %>
+	<%= f.input :date, default: (Date.today + @service.time_to_answer) %>
+	<%= f.submit class: "btn btn-primary"%>
 <% end %>
 
 


### PR DESCRIPTION
Não consegui deixar o calendário bonito ainda. Tem que usar Calendar Picker (mandei o link no slack). 

Nesse push, consegui: 
- colocar uma validação sob medida da data (mais de Today + time_to_answer) - Não sei como tirar o "Date" na frente da mensagem. 
- colocar essa data mínima como default na form


<img width="924" alt="image" src="https://user-images.githubusercontent.com/59183046/81756174-62fae500-9491-11ea-9a20-e9d68da1cf26.png">

<img width="924" alt="image" src="https://user-images.githubusercontent.com/59183046/81756309-c38a2200-9491-11ea-9708-8efd1b97ceb2.png">

