### PR TITLE
Fixed Time to answer validation

### DIFF
--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -2,7 +2,7 @@ class Booking < ApplicationRecord
   belongs_to :service
   belongs_to :user
   has_one :review, dependent: :destroy
-  validate :date_need_to_be_later_than_time_to_answer
+  validate :date_need_to_be_later_than_time_to_answer, on: :create
   
   def pending_confirmation?
     self.status == "Aguardando confirmação"


### PR DESCRIPTION
O validates se acionava para qualquer update da instância, o que bloqueava se a atualização acontecia dentro do prazo de time to answer ou depois do evento. 
Corrigi colocando a validação apenas no create (o que faz que a gente deveria proibir a alteração da data para uma reserva, mas acho que não vale a pena passar tempo nisso). 

